### PR TITLE
Adding additional catalog session parameters to category's cache key

### DIFF
--- a/app/code/community/Aligent/CacheObserver/Model/Observer.php
+++ b/app/code/community/Aligent/CacheObserver/Model/Observer.php
@@ -125,8 +125,19 @@ class Aligent_CacheObserver_Model_Observer{
         $params = Mage::app()->getRequest()->getParams();
         $logged = Mage::getSingleton('customer/session')->isLoggedIn() ? 'loggedin' : 'loggedout';
         if(!isset($params['limit'])){
-                if(Mage::getSingleton('catalog/session')->hasData('limit_page')){
-                        $params['limit'] = Mage::getSingleton('catalog/session')->getLimitPage();
+                $catalogSession = Mage::getSingleton('catalog/session');
+
+                $sessionParams = array(
+                        'limit_page' => 'limit',
+                        'display_mode' => 'mode',
+                        'sort_order' => 'order',
+                        'sort_direction' => 'dir'
+                );
+
+                foreach ($sessionParams as $sessionKey => $paramKey) {
+                        if ($catalogSession->hasData($sessionKey)) {
+                                $params[$paramKey] = $catalogSession->getData($sessionKey);
+                        }
                 }
         }
         unset($params['id']);


### PR DESCRIPTION
CacheObserver already factored in the category's product limit but was missing other dimensions that can be used to create a more accurate cache key particularly for product lists. These parameters were pulled from the `Enterprise_PageCache_Model_Processor_Category::$_paramsMap` property since they are used to generate the page id within that class.
