### PR TITLE
Add block caching support for enterprise targetrule items

### DIFF
--- a/app/code/community/Aligent/CacheObserver/Model/Observer.php
+++ b/app/code/community/Aligent/CacheObserver/Model/Observer.php
@@ -84,6 +84,14 @@ class Aligent_CacheObserver_Model_Observer{
                 $block->setData('cache_lifetime', self::CUSTOM_CACHE_LIFETIME);
                 $block->setData('cache_key', 'catalog_category_list_' . $sCachekey);
                 $block->setData('cache_tags', array(Mage_Core_Block_Abstract::CACHE_GROUP, Mage_Core_Model_App::CACHE_TAG, Mage_Core_Model_Store::CACHE_TAG, Mage_Catalog_Model_Product::CACHE_TAG, Mage_Catalog_Model_Category::CACHE_TAG.'_'.Mage::app()->getRequest()->getParam('id')));
+            } elseif ($block instanceof Enterprise_TargetRule_Block_Catalog_Product_Item && Mage::getStoreConfig(self::ENABLE_PRODUCT_VIEW)) {
+                if ($block->getProduct() !== null) {
+                    $iProductId = $block->getProduct()->getId();
+                } else {
+                    $iProductId = Mage::registry('orig_product_id') ? Mage::registry('orig_product_id') : Mage::app()->getRequest()->getParam('id');
+                }
+                $block->setData('cache_lifetime', self::CUSTOM_CACHE_LIFETIME);
+                $block->setData('cache_tags', array(Mage_Core_Block_Abstract::CACHE_GROUP, Mage_Core_Model_App::CACHE_TAG, Mage_Core_Model_Store::CACHE_TAG, Mage_Catalog_Model_Product::CACHE_TAG.'_'.$iProductId));
             } elseif ($block instanceof Mage_Catalog_Block_Product_Abstract && Mage::getStoreConfig(self::ENABLE_PRODUCT_VIEW)) {
                 if ($block->getProduct() !== null) {
                     $iProductId = $block->getProduct()->getId();
@@ -115,7 +123,7 @@ class Aligent_CacheObserver_Model_Observer{
                 $block->setData('cache_tags', array(Mage_Core_Block_Abstract::CACHE_GROUP, Mage_Core_Model_App::CACHE_TAG, Mage_Core_Model_Store::CACHE_TAG));
             }
         } catch (Exception $e) {
-            Mage::logException(e);
+            Mage::logException($e);
         }
     }
     


### PR DESCRIPTION
@aligentjim A new condition has been added to cache Enterprise TargetRule Product Items.  The block itself handles it's own generation of cache keys and cache key info but does not set cache lifetime. 
