### PR TITLE
Adding page variables and limitation varaiables that is exclusive for re...

### DIFF
--- a/app/code/community/Aligent/CacheObserver/Model/Observer.php
+++ b/app/code/community/Aligent/CacheObserver/Model/Observer.php
@@ -62,7 +62,7 @@ class Aligent_CacheObserver_Model_Observer{
                 $vReviewToolBarKey=$this->getReviewToolBarKey();
                 $block->setData('cache_lifetime', self::CUSTOM_CACHE_LIFETIME);
                 $block->setData('cache_key', 'review_product_view_list_' . $iProductId.(Mage::getSingleton('customer/session')->isLoggedIn() ? '_loggedin' : '_loggedout') . '_store_' . Mage::app()->getStore()->getId() . '_' . Mage::app()->getStore()->getCurrentCurrencyCode().'_'.$vReviewToolBarKey.$vAlias);
-                $block->setData('cache_tags', array(Mage_Core_Block_Abstract::CACHE_GROUP, Mage_Core_Model_App::CACHE_TAG, Mage_Core_Model_Store::CACHE_TAG, Mage_Catalog_Model_Product::CACHE_TAG.'_'.$vReviewToolBarKey.$iProductId));
+                $block->setData('cache_tags', array(Mage_Core_Block_Abstract::CACHE_GROUP, Mage_Core_Model_App::CACHE_TAG, Mage_Core_Model_Store::CACHE_TAG, Mage_Catalog_Model_Product::CACHE_TAG.'_'.$iProductId));
             } elseif ($block instanceof Mage_Review_Block_Product_View && Mage::getStoreConfig(self::ENABLE_PRODUCT_VIEW)) {
                 $iProductId = Mage::registry('orig_product_id') ? Mage::registry('orig_product_id') : Mage::app()->getRequest()->getParam('id');
                 $vAlias = $block->getNameInLayout();
@@ -75,7 +75,7 @@ class Aligent_CacheObserver_Model_Observer{
                 $vReviewToolBarKey=$this->getReviewToolBarKey();
                 $block->setData('cache_lifetime', self::CUSTOM_CACHE_LIFETIME);
                 $block->setData('cache_key', 'catalog_product_page_' . $iProductId.(Mage::getSingleton('customer/session')->isLoggedIn() ? '_loggedin' : '_loggedout') . '_store_' . Mage::app()->getStore()->getId() . '_' . Mage::app()->getStore()->getCurrentCurrencyCode().'_'.$vReviewToolBarKey.$vAlias);
-                $block->setData('cache_tags', array(Mage_Core_Block_Abstract::CACHE_GROUP, Mage_Core_Model_App::CACHE_TAG, Mage_Core_Model_Store::CACHE_TAG, Mage_Catalog_Model_Product::CACHE_TAG.'_'.$vReviewToolBarKey.$iProductId));
+                $block->setData('cache_tags', array(Mage_Core_Block_Abstract::CACHE_GROUP, Mage_Core_Model_App::CACHE_TAG, Mage_Core_Model_Store::CACHE_TAG, Mage_Catalog_Model_Product::CACHE_TAG.'_'.$iProductId));
             } elseif ($block instanceof Mage_Catalog_Block_Product_Price && Mage::getStoreConfig(self::ENABLE_PRODUCT_VIEW)) {
                 $iProductId = $block->getProduct() ? $block->getProduct()->getId() : Mage::app()->getRequest()->getParam('id');
                 $vAlias = $block->getNameInLayout();
@@ -102,10 +102,10 @@ class Aligent_CacheObserver_Model_Observer{
                 } else {
                     $iProductId = Mage::registry('orig_product_id') ? Mage::registry('orig_product_id') : Mage::app()->getRequest()->getParam('id');
                 }
-                $iPageId = $this->getParamKey(self::PAGE_VAR);
+                $vPageParamKey = $this->getParamKey(self::PAGE_VAR);
                 $vAlias = $block->getNameInLayout();
                 $block->setData('cache_lifetime', self::CUSTOM_CACHE_LIFETIME);
-                $block->setData('cache_key', 'catalog_product_abstractview_product_' . $iProductId.'_'.$iPageId.(Mage::getSingleton('customer/session')->isLoggedIn() ? '_loggedin' : '_loggedout') . '_store_' . Mage::app()->getStore()->getId() . '_' . Mage::app()->getStore()->getCurrentCurrencyCode().'_'.$vAlias);
+                $block->setData('cache_key', 'catalog_product_abstractview_product_' . $iProductId.'_'.$vPageParamKey.(Mage::getSingleton('customer/session')->isLoggedIn() ? '_loggedin' : '_loggedout') . '_store_' . Mage::app()->getStore()->getId() . '_' . Mage::app()->getStore()->getCurrentCurrencyCode().'_'.$vAlias);
                 $block->setData('cache_tags', array(Mage_Core_Block_Abstract::CACHE_GROUP, Mage_Core_Model_App::CACHE_TAG, Mage_Core_Model_Store::CACHE_TAG, Mage_Catalog_Model_Product::CACHE_TAG.'_'.$iProductId));
             } elseif ($block instanceof Mage_Catalog_Block_Category_View && Mage::getStoreConfig(self::ENABLE_CATEGORY_VIEW)) {
                 $sCachekey = $this->_generateCategoryCacheKey($observer, 'catalog_category_view');


### PR DESCRIPTION
...viewlist toolbar

to the cachekeys and cachetags of the catalog/product_view and review/product_view_list blocks.

@aligentjim : 
Issue: The "review/product_view_list" block did not retrieve appropriate content of reviews for any change regarding the page or limitation, such as page=1 or limit=20.
Fix: Creating unique cache key and cache tag for the  "review/product_view_list" block and its parent block, "catalog/product_view" based on the page variable and limitation variable from the request params(p/limit) resolved the above issue and fetched the right content. If these params are not present in the request, then it does not add them to the cache key and cache tag. 

Please CR and let me know your comments.

Thanks!
