### PR TITLE
Enterprise targetrule item fix

### DIFF
--- a/app/code/community/Aligent/CacheObserver/Model/Observer.php
+++ b/app/code/community/Aligent/CacheObserver/Model/Observer.php
@@ -84,6 +84,14 @@ class Aligent_CacheObserver_Model_Observer{
                 $block->setData('cache_lifetime', self::CUSTOM_CACHE_LIFETIME);
                 $block->setData('cache_key', 'catalog_category_list_' . $sCachekey);
                 $block->setData('cache_tags', array(Mage_Core_Block_Abstract::CACHE_GROUP, Mage_Core_Model_App::CACHE_TAG, Mage_Core_Model_Store::CACHE_TAG, Mage_Catalog_Model_Product::CACHE_TAG, Mage_Catalog_Model_Category::CACHE_TAG.'_'.Mage::app()->getRequest()->getParam('id')));
+            } elseif ($block instanceof Enterprise_TargetRule_Block_Catalog_Product_Item && Mage::getStoreConfig(self::ENABLE_PRODUCT_VIEW)) {
+                if ($block->getProduct() !== null) {
+                    $iProductId = $block->getProduct()->getId();
+                } else {
+                    $iProductId = Mage::registry('orig_product_id') ? Mage::registry('orig_product_id') : Mage::app()->getRequest()->getParam('id');
+                }
+                $block->setData('cache_lifetime', self::CUSTOM_CACHE_LIFETIME);
+                $block->setData('cache_tags', array(Mage_Core_Block_Abstract::CACHE_GROUP, Mage_Core_Model_App::CACHE_TAG, Mage_Core_Model_Store::CACHE_TAG, Mage_Catalog_Model_Product::CACHE_TAG.'_'.$iProductId));
             } elseif ($block instanceof Mage_Catalog_Block_Product_Abstract && Mage::getStoreConfig(self::ENABLE_PRODUCT_VIEW)) {
                 if ($block->getProduct() !== null) {
                     $iProductId = $block->getProduct()->getId();
@@ -115,7 +123,7 @@ class Aligent_CacheObserver_Model_Observer{
                 $block->setData('cache_tags', array(Mage_Core_Block_Abstract::CACHE_GROUP, Mage_Core_Model_App::CACHE_TAG, Mage_Core_Model_Store::CACHE_TAG));
             }
         } catch (Exception $e) {
-            Mage::logException(e);
+            Mage::logException($e);
         }
     }
     

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,10 @@
+{
+  "name":"aligent/cacheobserver",
+  "type":"magento-module",
+  "license":"OSL-3.0",
+  "homepage":"https://github.com/aligent/CacheObserver",
+  "description":"Magento extension to add cache keys and tags to blocks that are not cached by default.",
+  "require":{
+    "magento-hackathon/magento-composer-installer":"*"
+  }
+}


### PR DESCRIPTION
We still use the `models` branch in a project but just started running into an issue with the Enterprise TargetRule implementation. I traced it back to the CacheObserver module and noticed you have a fix in the `enterprise-targetrule-item-fix`. Would you be willing to merge that in with the `models` branch?