### PR TITLE
unit_test: fixed test for block match

### DIFF
--- a/app/code/community/Aligent/CacheObserver/Test/Model/Config.php
+++ b/app/code/community/Aligent/CacheObserver/Test/Model/Config.php
@@ -60,6 +60,7 @@ class Aligent_CacheObserver_Test_Model_Config extends EcomDev_PHPUnit_Test_Case
     public function testGetObserversByClassName($className)
     {
         $config    = $this->_config;
+        /** @var Aligent_CacheObserver_Model_Config $config */
         $observers = $config->getObserversByClassName($className);
         $this->assertTrue(is_array($observers), 'Expect observers to be an array.');
         $expectedObservers = $this->expected($className)->getObservers();

--- a/app/code/community/Aligent/CacheObserver/Test/Model/_data/fx-observer_config.yaml
+++ b/app/code/community/Aligent/CacheObserver/Test/Model/_data/fx-observer_config.yaml
@@ -1,4 +1,18 @@
 config_xml:
+  test: |
+      <test>
+        <events>
+            <core_block_abstract_to_html_before>
+                <observers>
+                    <cacheobserver2>
+                        <type>singleton</type>
+                        <class>cacheobserver/observer2</class>
+                        <method>customBlockCache</method>
+                    </cacheobserver2>
+                </observers>
+            </core_block_abstract_to_html_before>
+        </events>
+      </test>
   cacheObserver: |
       <cacheObserver>
           <cacheobserver_default>


### PR DESCRIPTION
testObserverCallsCacheObserverMethodWhenBlockMatches() expects observers would be called
this change adds events in test area
without it event wont get called in core_block_abstract_to_html_before