### PR TITLE
+ adds config nodes for adjusting lifetime by block, formkey placehol…

### DIFF
--- a/app/code/community/Aligent/CacheObserver/etc/config.xml
+++ b/app/code/community/Aligent/CacheObserver/etc/config.xml
@@ -71,6 +71,7 @@
         <system>
             <cacheobserver>
                 <cache_lifetime>14400</cache_lifetime>
+                <cache_lifetime_factor_lookup>{}</cache_lifetime_factor_lookup>
                 <enable_cms_pages>1</enable_cms_pages>
                 <enable_cms_blocks>1</enable_cms_blocks>
                 <enable_category_view>1</enable_category_view>

--- a/app/code/community/Aligent/CacheObserver/etc/system.xml
+++ b/app/code/community/Aligent/CacheObserver/etc/system.xml
@@ -26,6 +26,32 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </cache_lifetime>
+                        <cache_lifetime_factor_lookup>
+                            <label>Custom cache factors</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>6</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment>json encoded table of class name:factor pairs. Is multiplied by base lifetime. Used to modify the base cache lifetime for target blocks. ex: `{"Block_Name": 0.5}`</comment>
+                        </cache_lifetime_factor_lookup>
+                        <cache_formkey_placeholder>
+                            <label>FPC formkey placeholder</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>7</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </cache_formkey_placeholder>
+                        <cache_neverblocks>
+                            <label>Blocks to bypass caching</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>6</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment>Comma separated list of blocks to bypass</comment>
+                        </cache_neverblocks>
                         <enable_cms_pages translate="label comment">
                             <label>Enable Caching of CMS Pages</label>
                             <frontend_type>select</frontend_type>


### PR DESCRIPTION
Really really useful module.  

These are my changes that make it configurable enough to use without rewriting/overloading anything. For your consideration...

Most importantly the config is cached at startup (1 db hit). Extra blocks to ignore are added from the config (comma separated list), and a json array of block lifetime modifiers are loaded. The lifetime factors simply allow to extend or shorten lifetime for some blocks - for example if you might have cms block that could be safely cached for a day, but blocks that should get regenerated in only 60 seconds. Finally that FPC placeholder string is now configurable as well, removing the dependancy.

+ adds config nodes for adjusting lifetime by block, formkey placeholder, and blocks to bypass
* loads config in one go at construct, appends extra bypass blocks, and configures the formkey
* multiplies any configured cache lifetime factors by the base lifetime so blocks may be altered individually

example of cache lifetime factor config - if the base lifetime was 600 = 10m
then
{"Mage_Cms_Block_Block": 6,"Mage_Page_Block_Html_Footer":12}
would cache
Mage_Cms_Block_Block for 1hr and
Mage_Page_Block_Html_Footer for 2hrs